### PR TITLE
set up New Relic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ cython_debug/
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 geoip/*.mmdb
+newrelic.ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ psycopg2>=2.9.1,<2.10.0
 django-user-sessions>=1.7.1,<1.8.0
 geoip2>=4.4.0,<4.5.0
 django-xforwardedfor-middleware==2.0
+newrelic>=7.2.2,<7.3.0


### PR DESCRIPTION
For optional application monitoring. The Config file is not stored in Git but will need to be generated by the user with their own License key (Free).

If New Relic is not required then nothing is needed to be changed, simply don't provide the setup file.

Signed-off-by: Grant Ramsay <seapagan@gmail.com>